### PR TITLE
ステップ9: アプリの日本語部分を共通化しよう

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -57,3 +57,4 @@ end
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'dotenv-rails'
 gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
+gem 'rails-i18n'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -136,6 +136,9 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.3.0)
       loofah (~> 2.3)
+    rails-i18n (6.0.0)
+      i18n (>= 0.7, < 2)
+      railties (>= 6.0.0, < 7)
     railties (6.0.3.2)
       actionpack (= 6.0.3.2)
       activesupport (= 6.0.3.2)
@@ -229,6 +232,7 @@ DEPENDENCIES
   pry-rails
   puma (~> 3.11)
   rails (~> 6.0.3)
+  rails-i18n
   rubocop
   rubocop-performance
   rubocop-rails

--- a/app/javascript/components/tasks/NewAndEdit.vue
+++ b/app/javascript/components/tasks/NewAndEdit.vue
@@ -10,10 +10,10 @@
       <h1 v-else id="task-new-and-edit-title">Edit Task</h1>
       <div id="todo-info-container">
         <div id="todo-status-container">
-          type="radio" id="yet" value="1" v-model="inputTask.status" />
+          <input type="radio" id="yet" value="1" v-model="inputTask.status" />
           <label for="yet">Yet</label>
           <input id="doing" v-model="inputTask.status" type="radio" value="2" />
-          <label for="doing"> Doing</label>
+          <label for="doing">Doing</label>
 
           <input id="done" v-model="inputTask.status" type="radio" value="3" />
           <label for="done">Done</label>
@@ -23,17 +23,17 @@
           v-model="inputTask.title"
           type="text"
           placeholder="Enter your task title"
-          class="task-form-parts"/>
+          class="task-form-parts"
+        />
         <textarea
           id="task-form-content"
           v-model="inputTask.content"
           placeholder="Enter your task content"
-          class="task-form-parts"></textarea>
+          class="task-form-parts"
+        ></textarea>
       </div>
       <div id="task-submit-container">
-        <span id="submit" @click="submit()">
-          Submit
-        </span>
+        <span id="submit" @click="submit()">Submit</span>
       </div>
     </div>
   </section>
@@ -187,7 +187,7 @@ $done-color: white;
           align-items: center;
           box-sizing: border-box;
           padding: 30px 50px;
-          input[type='radio'] {
+          input[type="radio"] {
             display: none;
             + label {
               margin: 0 10px;

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -4,4 +4,7 @@ class Task < ApplicationRecord
   belongs_to :user
   has_many :tag_tasks, dependent: :destroy
   has_many :tags, through: :tag_tasks
+
+  validates :title, presence: true
+  validates :status, presence: true
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,4 +2,8 @@
 
 class User < ApplicationRecord
   has_many :tasks, dependent: :destroy
+
+  validates :name, presence: true
+  validates :email, presence: true
+  validates :password_digest, presence: true
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -28,7 +28,7 @@ module App
     #　以下の記述を追記する(設定必須)
     # デフォルトのlocaleを日本語(:ja)にする
     config.i18n.default_locale = :ja
-   config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.yml').to_s]
+    config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.yml').to_s]
     config.generators.system_tests = nil
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -23,13 +23,12 @@ module App
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.2
-
-    # Settings in config/environments/* take precedence over those specified here.
-    # Application configuration can go into files in config/initializers
-    # -- all .rb files in that directory are automatically loaded after loading
-    # the framework and any gems in your application.
-
-    # Don't generate system test files.
+    config.time_zone = 'Tokyo'
+    config.active_record.default_timezone = :local
+    #　以下の記述を追記する(設定必須)
+    # デフォルトのlocaleを日本語(:ja)にする
+    config.i18n.default_locale = :ja
+   config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.yml').to_s]
     config.generators.system_tests = nil
   end
 end

--- a/config/locales/model.ja.yml
+++ b/config/locales/model.ja.yml
@@ -1,0 +1,34 @@
+# モデルは全て activerecord 以下に記述する。
+# これにより、User.model_name.human / User.human_attribute_name({attr_name})で使用可能。
+
+ja:
+  activerecord:
+    models:
+      # view側： User.model_name.human => "ユーザ" / t("activerecord.models.user")と同じ
+      user: ユーザー
+      task: タスク
+      tag: タグ
+    # model毎に定義したいattributesを記述
+    attributes:
+      user:
+        id: ID
+        # view側： User.human_attribute_name :name => "名前" /　t("activerecord.attributes.user.name")と同じ
+        name: 名前
+        email: メールアドレス
+        image: プロフィール画像
+        password_digest: パスワード
+        permission: 許可
+        admin: 管理者
+        introduction: 自己紹介
+      task:
+        id: id
+        title: タイトル
+        content: タスク内容
+        status: ステータス
+        deadline: 締め切り
+        important: 優先度
+        user: 投稿者のID
+  # 全てのmodelで共通して使用するattråibutesを定義
+  attributes:
+    created_at: 作成日
+    updated_at: 更新日


### PR DESCRIPTION
## 処理概要
- バリデーションのエラーを発生させるために、UserとTaskにバリデーションを設定
- バリデーションのメッセージを日本語化

## 要件・仕様
- localesにmodel.ja.ymlを追加して、日本語の設定をしました
- task.rbとuser.rbにバリデーションの設定をしました

## 動作確認
実際にバリデーションに引っかかるようレコードの作成を試みると、日本語でエラーが表示されていると思います↓。
<img width="1680" alt="スクリーンショット 2020-08-03 10 43 03" src="https://user-images.githubusercontent.com/46987763/89138552-ea2e9500-d576-11ea-947b-927aba708851.png">


## 特記
- 実際に見た目の画面に日本語エラー文を反映させることに関してはステップ12でやりたいと思います。（resucueを用いて、jsonで日本語エラー文をフロントエンドに返してあげれば実装できそうです）

## 意見をもらいたい箇所 
- 実装上、動作確認時に確認すべき箇所がある場合は記載してください

## 参考
- 参考URLなどあれば
