### PR TITLE
ステップ10: Railsのタイムゾーンを設定しよう

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,12 @@
 FROM ruby:2.6.2
 ENV LANG C.UTF-8
-ENV TZ=Asia/Tokyo
+ENV TZ=Asia/Tokyo 
+# Timezoneを日本にした↑
 
 RUN /bin/cp -f /usr/share/zoneinfo/Asia/Tokyo /etc/localtime
 RUN curl -sL https://deb.nodesource.com/setup_14.x | bash - \
-    && apt-get update -qq \
-    && apt-get install -y build-essential nodejs postgresql-client git 
+  && apt-get update -qq \
+  && apt-get install -y build-essential nodejs postgresql-client git 
 
 ENV YARN_VERSION 1.13.0
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -23,8 +23,8 @@ module App
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.2
-    config.time_zone = 'Tokyo'
-    config.active_record.default_timezone = :local
+    config.time_zone = 'Tokyo'　#Timezoneを日本にした
+    config.active_record.default_timezone = :local #Timezoneを日本にした
     #　以下の記述を追記する(設定必須)
     # デフォルトのlocaleを日本語(:ja)にする
     config.i18n.default_locale = :ja

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -12,50 +10,51 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20_200_623_044_432) do
+ActiveRecord::Schema.define(version: 2020_06_23_044432) do
+
   # These are extensions that must be enabled in order to support this database
-  enable_extension 'plpgsql'
+  enable_extension "plpgsql"
 
-  create_table 'tag_tasks', force: :cascade do |t|
-    t.bigint 'tag_id', null: false
-    t.bigint 'task_id', null: false
-    t.datetime 'created_at', precision: 6, null: false
-    t.datetime 'updated_at', precision: 6, null: false
-    t.index ['tag_id'], name: 'index_tag_tasks_on_tag_id'
-    t.index ['task_id'], name: 'index_tag_tasks_on_task_id'
+  create_table "tag_tasks", force: :cascade do |t|
+    t.bigint "tag_id", null: false
+    t.bigint "task_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["tag_id"], name: "index_tag_tasks_on_tag_id"
+    t.index ["task_id"], name: "index_tag_tasks_on_task_id"
   end
 
-  create_table 'tags', force: :cascade do |t|
-    t.string 'title'
-    t.datetime 'created_at', precision: 6, null: false
-    t.datetime 'updated_at', precision: 6, null: false
+  create_table "tags", force: :cascade do |t|
+    t.string "title"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
-  create_table 'tasks', force: :cascade do |t|
-    t.string 'title'
-    t.text 'content'
-    t.integer 'status'
-    t.datetime 'deadline'
-    t.boolean 'important'
-    t.bigint 'user_id', null: false
-    t.datetime 'created_at', precision: 6, null: false
-    t.datetime 'updated_at', precision: 6, null: false
-    t.index ['user_id'], name: 'index_tasks_on_user_id'
+  create_table "tasks", force: :cascade do |t|
+    t.string "title"
+    t.text "content"
+    t.integer "status"
+    t.datetime "deadline"
+    t.boolean "important"
+    t.bigint "user_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["user_id"], name: "index_tasks_on_user_id"
   end
 
-  create_table 'users', force: :cascade do |t|
-    t.string 'name'
-    t.string 'email'
-    t.string 'password_digest'
-    t.string 'image'
-    t.text 'introduction'
-    t.boolean 'permission'
-    t.boolean 'admin'
-    t.datetime 'created_at', precision: 6, null: false
-    t.datetime 'updated_at', precision: 6, null: false
+  create_table "users", force: :cascade do |t|
+    t.string "name"
+    t.string "email"
+    t.string "password_digest"
+    t.string "image"
+    t.text "introduction"
+    t.boolean "permission"
+    t.boolean "admin"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
-  add_foreign_key 'tag_tasks', 'tags'
-  add_foreign_key 'tag_tasks', 'tasks'
-  add_foreign_key 'tasks', 'users'
+  add_foreign_key "tag_tasks", "tags"
+  add_foreign_key "tag_tasks", "tasks"
+  add_foreign_key "tasks", "users"
 end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: "3"
 services:
   db:
     image: postgres:9.6-alpine
@@ -6,16 +6,17 @@ services:
     volumes:
       - ./containers/db:/docker-entrypoint-initdb.d
     environment:
+      TZ: Asia/Tokyo
       POSTGRES_PASSWORD: pass
       POSTGRES_INITDB_ARGS: "--encoding=UTF-8 --locale=C"
     container_name: db
-  app:  &app_base
+  app: &app_base
     build:
       context: .
     volumes:
       - .:/var/src/app
     ports:
-      - '80:3000'
+      - "80:3000"
     environment:
       WEBPACKER_DEV_SERVER_HOST: webpack-dev-server
       RAILS_ENV: development
@@ -28,7 +29,7 @@ services:
     working_dir: /var/src/app
     command: /bin/sh -c "rm -f /var/src/app/tmp/pids/server.pid;bundle exec rails s -b 0.0.0.0"
     cap_add:
-      - ALL  # Add all privilege
+      - ALL # Add all privilege
     container_name: app
     tty: true
     stdin_open: true
@@ -43,7 +44,7 @@ services:
     build: .
     command: /bin/sh -c "bin/webpack-dev-server --hot --inline"
     ports:
-      - '3035:3035'
+      - "3035:3035"
     environment:
       WEBPACKER_DEV_SERVER_HOST: 0.0.0.0
     volumes:
@@ -52,4 +53,3 @@ services:
     stdin_open: true
     depends_on:
       - app
-


### PR DESCRIPTION
## 処理概要
- Rails(Ruby)とPostgres SQLのTimezoneをJST(Asia/Tokyo)にしました

## 要件・仕様
-  Rails(Ruby)のTimezoneの設定 → apprication.rbとDockerfileに追記
- Postgres SQLのTimezoneの設定 → docker-compose.ymlに追記
## 動作確認
- 以下の画像上半分でPostgres のTimezoneがAsia/Tokyoに、画像下半分でRails(Ruby)のTImezoneがJSTと表示されていることがわかります。
<img width="1068" alt="スクリーンショット 2020-08-04 13 40 26" src="https://user-images.githubusercontent.com/46987763/89254478-27b81e80-d65a-11ea-952b-258355fb21ff.png">


## 特記
- 

## 意見をもらいたい箇所 
- Dockerfileとdocker-compose.ymlと、apprication.rbの確認をお願いします。

## 参考
- <a href='https://qiita.com/aosho235/items/a31b895ce46ee5d3b444'>Railsタイムゾーンまとめ<a/>
