### PR TITLE
ステップ11: タスク一覧を作成日時の順番で並び替えよう

### DIFF
--- a/app/controllers/api/tasks_controller.rb
+++ b/app/controllers/api/tasks_controller.rb
@@ -29,7 +29,7 @@ class Api::TasksController < ApplicationController
   private
 
   def returnTasksAndUsersAllData
-    tasks = Task.all.order(created_at: 'DESC') # 新しい順
+    tasks = Task.all.order(created_at: 'DESC') # 新しい順です
     users = User.all
     info = {
       tasks: tasks,

--- a/app/javascript/components/tasks/TaskListCard.vue
+++ b/app/javascript/components/tasks/TaskListCard.vue
@@ -1,5 +1,8 @@
 <template>
   <div class="todo-card">
+    <span class="todo-created-at">{{
+      task.created_at | convert_time_format
+    }}</span>
     <span class="task-title">{{ task.title }}</span>
     <div class="task-card-buttons">
       <span class="status-marker">
@@ -7,19 +10,20 @@
         <span v-else-if="task.status === 2" class="doing">Doing</span>
         <span v-else-if="task.status === 3" class="done">Done</span>
       </span>
-      <span class="show-task-button" @click="SetShowFunc(task)"
-        ><i class="fas fa-info-circle"></i
-      ></span>
-      <span class="edit-task-button" @click="SetEditFunc(task)"
-        ><i class="fas fa-edit"></i
-      ></span>
-      <span class="delete-task-button" @click="Destroy()"
-        ><i class="fas fa-trash"></i
-      ></span>
+      <span class="show-task-button" @click="SetShowFunc(task)">
+        <i class="fas fa-info-circle"></i>
+      </span>
+      <span class="edit-task-button" @click="SetEditFunc(task)">
+        <i class="fas fa-edit"></i>
+      </span>
+      <span class="delete-task-button" @click="Destroy()">
+        <i class="fas fa-trash"></i>
+      </span>
     </div>
   </div>
 </template>
 <script>
+import moment from "moment";
 export default {
   props: {
     task: Object,
@@ -58,6 +62,11 @@ export default {
         });
     },
   },
+  filters: {
+    convert_time_format: function (value) {
+      return moment(value).format("YYYY年 MM月DD日 HH:mm");
+    },
+  },
 };
 </script>
 <style lang="scss" scoped>
@@ -81,6 +90,15 @@ $done-color: white;
     display: flex;
     flex-direction: row;
     justify-content: space-between;
+    position: relative;
+    margin: 20px 0;
+    .todo-created-at {
+      position: absolute;
+      top: -40px;
+      left: 0;
+      padding: 5px 10px;
+      font-size: 1rem;
+    }
     .task-title {
       font-size: 1.3rem;
     }

--- a/config/application.rb
+++ b/config/application.rb
@@ -23,7 +23,7 @@ module App
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.2
-    config.time_zone = 'Tokyo'　#Timezoneを日本にした
+    config.time_zone = 'Tokyo' #Timezoneを日本にした
     config.active_record.default_timezone = :local #Timezoneを日本にした
     #　以下の記述を追記する(設定必須)
     # デフォルトのlocaleを日本語(:ja)にする

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "dependencies": {
     "@rails/webpacker": "5.1.1",
     "axios": "^0.19.2",
+    "moment": "^2.27.0",
     "vue": "^2.6.11",
     "vue-axios": "^2.1.5",
     "vue-eslint-parser": "^7.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4813,6 +4813,11 @@ mixin-deep@^1.2.0:
   dependencies:
     minimist "^1.2.5"
 
+moment@^2.27.0:
+  version "2.27.0"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.27.0.tgz#8bff4e3e26a236220dfe3e36de756b6ebaa0105d"
+  integrity sha512-al0MUK7cpIcglMv3YF13qSgdAIqxHTO7brRtaz3DlSULbqfazqkc5kEjNrLDOM7fsjshoFIihnU8snrP7zUvhQ==
+
 move-concurrently@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/move-concurrently/-/move-concurrently-1.0.1.tgz#be2c005fda32e0b29af1f05d7c4b33214c701f92"


### PR DESCRIPTION
## 処理概要
- タスクの並びを、created_atで降順にしました
- 該当のカリキュラムは[こちらです](https://github.com/buysell-technologies/el-training/blob/master/docs/el-training.md#%E3%82%B9%E3%83%86%E3%83%83%E3%83%9711-%E3%82%BF%E3%82%B9%E3%82%AF%E4%B8%80%E8%A6%A7%E3%82%92%E4%BD%9C%E6%88%90%E6%97%A5%E6%99%82%E3%81%AE%E9%A0%86%E7%95%AA%E3%81%A7%E4%B8%A6%E3%81%B3%E6%9B%BF%E3%81%88%E3%82%88%E3%81%86)

## 要件・仕様
- api/tasks_controller.rbのreturnTasksAndUsersAllData関数でDESC指定をしています
- ブラウザでも降順になっているかどうか、並びがわかるようにタスク一覧ページに、created_atの表記を追加しました(moment.jsを用いてフォーマットを整形しています）。

## 動作確認
- 新しいものから順番に並んでいることがわかります。
<img width="1907" alt="スクリーンショット 2020-08-11 11 52 38" src="https://user-images.githubusercontent.com/46987763/89852555-1b881000-dbca-11ea-9ca9-469858c368c7.png">


## 特記
- System Specを用いたテストは不要とのことなので、やっていません

## 意見をもらいたい箇所 
- 

## 参考
- 
