### PR TITLE
【WIP】 tasksテーブルとusersテーブルにバリデーションを追加

### DIFF
--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -5,8 +5,8 @@ class Task < ApplicationRecord
   has_many :tag_tasks, dependent: :destroy
   has_many :tags, through: :tag_tasks
 
-  validates :title, length: { in: 1..30 } # タイトルは１文字以上30文字以下
+  validates :title, presence:true ,length: { maximum: 30} # タイトルは１文字以上30文字以下
   validates :content, presence: true
-  validates :status, numericality: { only_integer: true, greater_than_or_equal_to: 1, less_than_or_equal_to: 3 } # statusは　１　＝　未着手　, 2 = 着手中　, ３　＝　履行済　なので、１、２、３以外は弾く
+  validates :status, presence:true, numericality: { only_integer: true, greater_than_or_equal_to: 1, less_than_or_equal_to: 3 } # statusは　１　＝　未着手　, 2 = 着手中　, ３　＝　履行済　なので、１、２、３以外は弾く
   validates :important, inclusion: { in: [true, false] }
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -5,8 +5,8 @@ class Task < ApplicationRecord
   has_many :tag_tasks, dependent: :destroy
   has_many :tags, through: :tag_tasks
 
-  validates :title, presence:true ,length: { maximum: 30} # タイトルは１文字以上30文字以下
+  validates :title, presence: true, length: { maximum: 30 } # タイトルは１文字以上30文字以下
   validates :content, presence: true
-  validates :status, presence:true, numericality: { only_integer: true, greater_than_or_equal_to: 1, less_than_or_equal_to: 3 } # statusは　１　＝　未着手　, 2 = 着手中　, ３　＝　履行済　なので、１、２、３以外は弾く
+  validates :status, presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 1, less_than_or_equal_to: 3 } # statusは　１　＝　未着手　, 2 = 着手中　, ３　＝　履行済　なので、１、２、３以外は弾く
   validates :important, inclusion: { in: [true, false] }
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -5,8 +5,8 @@ class Task < ApplicationRecord
   has_many :tag_tasks, dependent: :destroy
   has_many :tags, through: :tag_tasks
 
-  validates :title, presence: true, length: { in: 1..30 } # タイトルは１文字以上30文字以下
+  validates :title, length: { in: 1..30 } # タイトルは１文字以上30文字以下
   validates :content, presence: true
-  validates :status, presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 1, less_than_or_equal_to: 3 } # statusは　１　＝　未着手　, 2 = 着手中　, ３　＝　履行済　なので、１、２、３以外は弾く
-  validates :important, presence: true, inclusion: { in: [true, false] }
+  validates :status, numericality: { only_integer: true, greater_than_or_equal_to: 1, less_than_or_equal_to: 3 } # statusは　１　＝　未着手　, 2 = 着手中　, ３　＝　履行済　なので、１、２、３以外は弾く
+  validates :important, inclusion: { in: [true, false] }
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -5,6 +5,8 @@ class Task < ApplicationRecord
   has_many :tag_tasks, dependent: :destroy
   has_many :tags, through: :tag_tasks
 
-  validates :title, presence: true
-  validates :status, presence: true
+  validates :title, presence: true, length: { in: 1..30 } # タイトルは１文字以上30文字以下
+  validates :content, presence: true
+  validates :status, presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 1, less_than_or_equal_to: 3 } # statusは　１　＝　未着手　, 2 = 着手中　, ３　＝　履行済　なので、１、２、３以外は弾く
+  validates :important, presence: true, inclusion: { in: [true, false] }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 
 class User < ApplicationRecord
-  before_save { self.email = email.downcase }  # メールアドレスは大文字・小文字を区別しないので、データベースに登録前に小文字に戻す 
+  before_save { self.email = email.downcase } # メールアドレスは大文字・小文字を区別しないので、データベースに登録前に小文字に戻す
   VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i.freeze
-  
+
   has_many :tasks, dependent: :destroy
 
   validates :name, presence: true, length: { in: 1..20 } # 名前は１文字以上20文字以下
-  validates :email, presence: true, format: { with: VALID_EMAIL_REGEX },uniqueness: { case_sensitive: false } # uniqueness:{ case_sensitive: false }で、メールアドレスのバリデーションで、大文字・小文字の区別を無くしている　
+  validates :email, presence: true, format: { with: VALID_EMAIL_REGEX }, uniqueness: { case_sensitive: false } # uniqueness:{ case_sensitive: false }で、メールアドレスのバリデーションで、大文字・小文字の区別を無くしている　
   validates :password_digest, presence: true
   validates :introduction, length: { maximum: 150 }
   validates :permission, presence: true, inclusion: { in: [true, false] }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,7 +6,7 @@ class User < ApplicationRecord
 
   has_many :tasks, dependent: :destroy
 
-  validates :name, presence:true ,length: { maximum: 20} # 名前は１文字以上20文字以下
+  validates :name, presence: true, length: { maximum: 20 } # 名前は１文字以上20文字以下
   validates :email, presence: true, format: { with: VALID_EMAIL_REGEX }, uniqueness: { case_sensitive: false } # uniqueness:{ case_sensitive: false }で、メールアドレスのバリデーションで、大文字・小文字の区別を無くしている　
   validates :password_digest, presence: true
   validates :introduction, length: { maximum: 150 }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,7 +6,7 @@ class User < ApplicationRecord
 
   has_many :tasks, dependent: :destroy
 
-  validates :name, length: { in: 1..20 } # 名前は１文字以上20文字以下
+  validates :name, presence:true ,length: { maximum: 20} # 名前は１文字以上20文字以下
   validates :email, presence: true, format: { with: VALID_EMAIL_REGEX }, uniqueness: { case_sensitive: false } # uniqueness:{ case_sensitive: false }で、メールアドレスのバリデーションで、大文字・小文字の区別を無くしている　
   validates :password_digest, presence: true
   validates :introduction, length: { maximum: 150 }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,9 +1,15 @@
 # frozen_string_literal: true
 
 class User < ApplicationRecord
+  before_save { self.email = email.downcase }  # メールアドレスは大文字・小文字を区別しないので、データベースに登録前に小文字に戻す 
+  VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i.freeze
+  
   has_many :tasks, dependent: :destroy
 
-  validates :name, presence: true
-  validates :email, presence: true
+  validates :name, presence: true, length: { in: 1..20 } # 名前は１文字以上20文字以下
+  validates :email, presence: true, format: { with: VALID_EMAIL_REGEX },uniqueness: { case_sensitive: false } # uniqueness:{ case_sensitive: false }で、メールアドレスのバリデーションで、大文字・小文字の区別を無くしている　
   validates :password_digest, presence: true
+  validates :introduction, length: { maximum: 150 }
+  validates :permission, presence: true, inclusion: { in: [true, false] }
+  validates :admin, presence: true, inclusion: { in: [true, false] }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,10 +6,10 @@ class User < ApplicationRecord
 
   has_many :tasks, dependent: :destroy
 
-  validates :name, presence: true, length: { in: 1..20 } # 名前は１文字以上20文字以下
+  validates :name, length: { in: 1..20 } # 名前は１文字以上20文字以下
   validates :email, presence: true, format: { with: VALID_EMAIL_REGEX }, uniqueness: { case_sensitive: false } # uniqueness:{ case_sensitive: false }で、メールアドレスのバリデーションで、大文字・小文字の区別を無くしている　
   validates :password_digest, presence: true
   validates :introduction, length: { maximum: 150 }
-  validates :permission, presence: true, inclusion: { in: [true, false] }
-  validates :admin, presence: true, inclusion: { in: [true, false] }
+  validates :permission, inclusion: { in: [true, false] }
+  validates :admin, inclusion: { in: [true, false] }
 end

--- a/db/migrate/20200817014423_add_validation_to_task.rb
+++ b/db/migrate/20200817014423_add_validation_to_task.rb
@@ -1,0 +1,8 @@
+class AddValidationToTask < ActiveRecord::Migration[6.0]
+  def up   # change_columnは、def changeではなく、　def up にしないと、ロールバック時にエラーが出るとのことなので
+    change_column :tasks, :title, :string, limit: 30, null: false
+    change_column :tasks, :content, :text, default: "タスクの内容はまだ決まっていません。", null: false
+    change_column :tasks, :status, :integer, default: 1 , null: false
+    change_column :tasks, :important, :boolean, default: false, null: false
+  end
+end

--- a/db/migrate/20200817020422_add_validation_to_user.rb
+++ b/db/migrate/20200817020422_add_validation_to_user.rb
@@ -1,0 +1,11 @@
+class AddValidationToUser < ActiveRecord::Migration[6.0]
+  def up  # change_columnは、def changeではなく、　def up にしないと、ロールバック時にエラーが出るとのことなので
+    change_column :users, :name, :string, limit: 20, null: false
+    change_column :users, :email, :string, limit: 50, null: false, unique: true
+    add_index :users, :email, unique: true
+    change_column :users, :password_digest, :string, null: false
+    change_column :users, :introduction, :text, limit: 150
+    change_column :users, :permission, :boolean, default: false, null: false
+    change_column :users, :admin, :boolean, default: false, null: false
+  end
+end

--- a/db/migrate/20200817020422_add_validation_to_user.rb
+++ b/db/migrate/20200817020422_add_validation_to_user.rb
@@ -2,7 +2,6 @@ class AddValidationToUser < ActiveRecord::Migration[6.0]
   def up  # change_columnは、def changeではなく、　def up にしないと、ロールバック時にエラーが出るとのことなので
     change_column :users, :name, :string, limit: 20, null: false
     change_column :users, :email, :string, limit: 50, null: false, unique: true
-    add_index :users, :email, unique: true
     change_column :users, :password_digest, :string, null: false
     change_column :users, :introduction, :text, limit: 150
     change_column :users, :permission, :boolean, default: false, null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_23_044432) do
+ActiveRecord::Schema.define(version: 2020_08_17_020422) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -31,11 +31,11 @@ ActiveRecord::Schema.define(version: 2020_06_23_044432) do
   end
 
   create_table "tasks", force: :cascade do |t|
-    t.string "title"
-    t.text "content"
-    t.integer "status"
+    t.string "title", limit: 30, null: false
+    t.text "content", default: "タスクの内容はまだ決まっていません。", null: false
+    t.integer "status", default: 1, null: false
     t.datetime "deadline"
-    t.boolean "important"
+    t.boolean "important", default: false, null: false
     t.bigint "user_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
@@ -43,15 +43,16 @@ ActiveRecord::Schema.define(version: 2020_06_23_044432) do
   end
 
   create_table "users", force: :cascade do |t|
-    t.string "name"
-    t.string "email"
-    t.string "password_digest"
+    t.string "name", limit: 20, null: false
+    t.string "email", limit: 50, null: false
+    t.string "password_digest", null: false
     t.string "image"
     t.text "introduction"
-    t.boolean "permission"
-    t.boolean "admin"
+    t.boolean "permission", default: false, null: false
+    t.boolean "admin", default: false, null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.index ["email"], name: "index_users_on_email", unique: true
   end
 
   add_foreign_key "tag_tasks", "tags"


### PR DESCRIPTION
## 処理概要
- usersテーブルとtasksテーブルの各カラムにバリデーションを追加しました。

## 要件・仕様
- User.rbとTask.rbにいくつかバリデーションを設定しています。
- マイグレーションファイルを用いて、DB側にもバリデーションを追加しました。

## 動作確認
- テストコードをカリキュラムではかいていないので、コンソールで試しました↓
<img width="1907" alt="スクリーンショット 2020-08-17 11 53 10" src="https://user-images.githubusercontent.com/46987763/90353189-9779d080-e080-11ea-90fa-1f0102aaf01a.png">
<img width="1907" alt="スクリーンショット 2020-08-17 11 50 59" src="https://user-images.githubusercontent.com/46987763/90353191-9c3e8480-e080-11ea-98db-ab82971f138c.png">


## 特記
- file changedが多くなる前に、区切りのいいバリデーション実装のタイミングで、いったんWIPとして出しました。

## 意見をもらいたい箇所 
- バリデーション不慣れなので、この書き方でOKなのかが不安です。確認をお願いします。

## 参考
- <a href='https://railsguides.jp/active_record_migrations.html'> Rails ガイドActive Record マイグレーション </a>
- <a href='https://qiita.com/aiorange19/items/6f7d1d0f7582b5159b65'>メールアドレスのバリデーション</a>
- <a href='https://qiita.com/takuyanin/items/6d51ffb4078a417fed35' > change_columnでの設定はrollbackできない話(This migration uses change_column, which is not automatically reversible.)[Rails] </a>
- <a href='https://qiita.com/h1kita/items/772b81a1cc066e67930e'>Rails バリデーションまとめ</a>