### PR TITLE
バリデーションエラーがブラウザに表示されるようにしました。

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ gem 'pg', '~> 1.1.4'
 gem 'puma', '~> 3.11'
 gem 'webpacker'
 # Use SCSS for stylesheets
-gem 'sassc-rails'
+# gem 'sassc-rails'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem 'jbuilder', '~> 2.5'
 # Use Redis adapter to run Action Cable in production

--- a/app/controllers/api/tasks_controller.rb
+++ b/app/controllers/api/tasks_controller.rb
@@ -9,20 +9,22 @@ class Api::TasksController < ApplicationController
     task = Task.new(task_params)
     task.deadline = DateTime.now
     task.user_id = 1 # まだログイン機能をつけてないので
-    begin
-      returnTasksAndUsersAllData if task.save!
-    rescue StandardError => e
+    returnTasksAndUsersAllData if task.save!
+    rescue ActiveRecord::RecordInvalid,
+           ActiveRecord::RecordNotSave,
+           ActiveRecord::RecordNotUnique,
+           ActiveRecord::StatementInvalid => e
       render status: :internal_server_error, json: { error: e }
-    end
   end
 
   def update
     task = Task.find(params[:id])
-    begin
-      returnTasksAndUsersAllData if task.update!(task_params)
-    rescue StandardError => e
+    returnTasksAndUsersAllData if task.update!(task_params)
+    rescue ActiveRecord::RecordInvalid,
+           ActiveRecord::RecordNotSave,
+           ActiveRecord::RecordNotUnique,
+           ActiveRecord::StatementInvalid => e
       render status: :internal_server_error, json: { error: e }
-    end
   end
 
   def destroy

--- a/app/controllers/api/tasks_controller.rb
+++ b/app/controllers/api/tasks_controller.rb
@@ -11,27 +11,17 @@ class Api::TasksController < ApplicationController
     task.user_id = 1 # まだログイン機能をつけてないので
     task.save!
     returnTasksAndUsersAllData
-    rescue ActiveRecord::RecordInvalid,
-           ActiveRecord::RecordNotSave,
-           ActiveRecord::RecordNotUnique,
-           ActiveRecord::StatementInvalid => e
-      render status: :internal_server_error, json: { error: e }
   end
 
   def update
     task = Task.find(params[:id])
     task.update!(task_params)
-    returnTasksAndUsersAllData 
-    rescue ActiveRecord::RecordInvalid,
-           ActiveRecord::RecordNotSave,
-           ActiveRecord::RecordNotUnique,
-           ActiveRecord::StatementInvalid => e
-      render status: :internal_server_error, json: { error: e }
+    returnTasksAndUsersAllData
   end
 
   def destroy
     task = Task.find(params[:id])
-    if task.destroy
+    if task.destroy!
       returnTasksAndUsersAllData
     else
       render json: { message: 'failed' }

--- a/app/controllers/api/tasks_controller.rb
+++ b/app/controllers/api/tasks_controller.rb
@@ -9,12 +9,21 @@ class Api::TasksController < ApplicationController
     task = Task.new(task_params)
     task.deadline = DateTime.now
     task.user_id = 1 # まだログイン機能をつけてないので
-    returnTasksAndUsersAllData if task.save!
+    begin
+      returnTasksAndUsersAllData if task.save!
+    rescue => error
+      render status:500 ,json: { error: error }
+    end
+    
   end
 
   def update
     task = Task.find(params[:id])
+    begin
     returnTasksAndUsersAllData if task.update!(task_params)
+    rescue => error
+      render status:500 ,json: { error: error }
+    end
   end
   
   def destroy

--- a/app/controllers/api/tasks_controller.rb
+++ b/app/controllers/api/tasks_controller.rb
@@ -9,7 +9,8 @@ class Api::TasksController < ApplicationController
     task = Task.new(task_params)
     task.deadline = DateTime.now
     task.user_id = 1 # まだログイン機能をつけてないので
-    returnTasksAndUsersAllData if task.save!
+    task.save!
+    returnTasksAndUsersAllData
     rescue ActiveRecord::RecordInvalid,
            ActiveRecord::RecordNotSave,
            ActiveRecord::RecordNotUnique,
@@ -19,7 +20,8 @@ class Api::TasksController < ApplicationController
 
   def update
     task = Task.find(params[:id])
-    returnTasksAndUsersAllData if task.update!(task_params)
+    task.update!(task_params)
+    returnTasksAndUsersAllData 
     rescue ActiveRecord::RecordInvalid,
            ActiveRecord::RecordNotSave,
            ActiveRecord::RecordNotUnique,

--- a/app/controllers/api/tasks_controller.rb
+++ b/app/controllers/api/tasks_controller.rb
@@ -11,21 +11,20 @@ class Api::TasksController < ApplicationController
     task.user_id = 1 # まだログイン機能をつけてないので
     begin
       returnTasksAndUsersAllData if task.save!
-    rescue => error
-      render status:500 ,json: { error: error }
+    rescue StandardError => e
+      render status: :internal_server_error, json: { error: e }
     end
-    
   end
 
   def update
     task = Task.find(params[:id])
     begin
-    returnTasksAndUsersAllData if task.update!(task_params)
-    rescue => error
-      render status:500 ,json: { error: error }
+      returnTasksAndUsersAllData if task.update!(task_params)
+    rescue StandardError => e
+      render status: :internal_server_error, json: { error: e }
     end
   end
-  
+
   def destroy
     task = Task.find(params[:id])
     if task.destroy
@@ -34,7 +33,7 @@ class Api::TasksController < ApplicationController
       render json: { message: 'failed' }
     end
   end
-  
+
   private
 
   def returnTasksAndUsersAllData
@@ -51,4 +50,3 @@ class Api::TasksController < ApplicationController
     params.require(:inputTask).permit(:id, :user_id, :created_at, :updated_at, :title, :content, :status, :deadline, :important)
   end
 end
-

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,14 @@
 # frozen_string_literal: true
 
 class ApplicationController < ActionController::Base
+  rescue_from  ActiveRecord::RecordInvalid, with: :rescue_validation_error
+  rescue_from  ActiveRecord::RecordNotUnique, with: :rescue_validation_error
+  rescue_from  ActiveRecord::RecordNotSaved, with: :rescue_validation_error
+  rescue_from  ActiveRecord::StatementInvalid, with: :rescue_validation_error
+
+  private
+
+  def rescue_validation_error(error)
+    render status: :internal_server_error, json: { error: error}
+  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,14 +1,22 @@
 # frozen_string_literal: true
 
 class ApplicationController < ActionController::Base
-  rescue_from  ActiveRecord::RecordInvalid, with: :rescue_validation_error
-  rescue_from  ActiveRecord::RecordNotUnique, with: :rescue_validation_error
-  rescue_from  ActiveRecord::RecordNotSaved, with: :rescue_validation_error
-  rescue_from  ActiveRecord::StatementInvalid, with: :rescue_validation_error
+  rescue_from  ActiveRecord::RecordInvalid, with: :rescue_validation_422_error
+  rescue_from  ActiveRecord::RecordNotUnique, with: :rescue_validation_500_error
+  rescue_from  ActiveRecord::RecordNotSaved, with: :rescue_validation_422_error
+  rescue_from  ActiveRecord::StatementInvalid, with: :rescue_validation_500_error
+  rescue_from  ActiveRecord::RecordNotDestroyed,with: :rescue_validation_500_error
+  rescue_from  ActiveRecord::RecordNotFound, with: :rescue_validation_404_error   
 
   private
 
-  def rescue_validation_error(error)
-    render status: :internal_server_error, json: { error: error }
+  def rescue_validation_422_error(error)
+    render status:422, json: { error: error }
+  end
+  def rescue_validation_500_error(error)
+    render status:500, json: { error: error }
+  end
+  def rescue_validation_404_error(error)
+    render status:404, json: { error: error }
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,22 +1,24 @@
 # frozen_string_literal: true
 
 class ApplicationController < ActionController::Base
-  rescue_from  ActiveRecord::RecordInvalid, with: :rescue_validation_422_error
-  rescue_from  ActiveRecord::RecordNotUnique, with: :rescue_validation_500_error
-  rescue_from  ActiveRecord::RecordNotSaved, with: :rescue_validation_422_error
-  rescue_from  ActiveRecord::StatementInvalid, with: :rescue_validation_500_error
-  rescue_from  ActiveRecord::RecordNotDestroyed,with: :rescue_validation_500_error
-  rescue_from  ActiveRecord::RecordNotFound, with: :rescue_validation_404_error   
+  rescue_from  ActiveRecord::RecordInvalid, with: :rescue_422_error
+  rescue_from  ActiveRecord::RecordNotUnique, with: :rescue_500_error
+  rescue_from  ActiveRecord::RecordNotSaved, with: :rescue_422_error
+  rescue_from  ActiveRecord::StatementInvalid, with: :rescue_500_error
+  rescue_from  ActiveRecord::RecordNotDestroyed, with: :rescue_500_error
+  rescue_from  ActiveRecord::RecordNotFound, with: :rescue_404_error
 
   private
 
-  def rescue_validation_422_error(error)
-    render status:422, json: { error: error }
+  def rescue_422_error(error)
+    render status: :unprocessable_entity, json: { error: error }
   end
-  def rescue_validation_500_error(error)
-    render status:500, json: { error: error }
+
+  def rescue_500_error(error)
+    render status: :internal_server_error, json: { error: error }
   end
-  def rescue_validation_404_error(error)
-    render status:404, json: { error: error }
+
+  def rescue_404_error(error)
+    render status: :not_found, json: { error: error }
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,6 +9,6 @@ class ApplicationController < ActionController::Base
   private
 
   def rescue_validation_error(error)
-    render status: :internal_server_error, json: { error: error}
+    render status: :internal_server_error, json: { error: error }
   end
 end

--- a/app/javascript/components/tasks/NewAndEdit.vue
+++ b/app/javascript/components/tasks/NewAndEdit.vue
@@ -97,8 +97,8 @@ export default {
             this.$emit("update:is_new_and_edit", false);
           })
           .catch((error) => {
-            console.log(error);
-            alert("エラーが起きました！");
+            console.dir(error);
+            alert(error.response.data.error.replace('バリデーションに失敗しました:', ""));
           });
       } else {
         //更新の場合
@@ -114,7 +114,7 @@ export default {
           })
           .catch((error) => {
             console.log(error);
-            alert("エラーが起きました！");
+            alert(error.response.data.error.replace('バリデーションに失敗しました:', ""));
           });
       }
     },

--- a/app/javascript/components/tasks/NewAndEdit.vue
+++ b/app/javascript/components/tasks/NewAndEdit.vue
@@ -113,7 +113,7 @@ export default {
             this.$emit("update:is_new_and_edit", false);
           })
           .catch((error) => {
-            console.log(error);
+            console.dir(error);
             alert(error.response.data.error.replace('バリデーションに失敗しました:', ""));
           });
       }

--- a/app/javascript/components/tasks/TaskListCard.vue
+++ b/app/javascript/components/tasks/TaskListCard.vue
@@ -1,8 +1,10 @@
 <template>
   <div class="todo-card">
-    <span class="todo-created-at">{{
+    <span class="todo-created-at">
+      {{
       task.created_at | convert_time_format
-    }}</span>
+      }}
+    </span>
     <span class="task-title">{{ task.title }}</span>
     <div class="task-card-buttons">
       <span class="status-marker">

--- a/app/javascript/views/tasks/Index.vue
+++ b/app/javascript/views/tasks/Index.vue
@@ -2,23 +2,16 @@
   <section id="tasks-index">
     <h1 id="tasks-index-title">Your Tasks</h1>
     <div id="task-new-button-container">
-      <span id="task-new-button" @click="newFunc()">
-        Add a Task
-      </span>
+      <span id="task-new-button" @click="newFunc()">Add a Task</span>
     </div>
-    <div
-      v-if="tasks && users"
-      v-show="!is_show && !is_new_and_edit"
-      id="tasks-container"
-    >
+    <div v-if="tasks && users" v-show="!is_show && !is_new_and_edit" id="tasks-container">
       <span v-for="(task, index) in tasks" :key="index" class="each-todo">
         <TaskListCard
           :task="task"
           :show-func="showFunc"
           :edit-func="editFunc"
           :refreshTasksAllData="refreshTasksAllData"
-        >
-        </TaskListCard>
+        ></TaskListCard>
       </span>
     </div>
     <transition name="fade">
@@ -49,13 +42,13 @@
           :is_new_and_edit.sync="is_new_and_edit"
           :is_new="is_new"
           :refresh-tasks-all-data="refreshTasksAllData"
-        >
-        </TaskNewAndEdit>
+        ></TaskNewAndEdit>
       </div>
     </transition>
   </section>
 </template>
 <script>
+'use strict';
 import TaskListCard from "../../components/tasks/TaskListCard";
 import TaskShow from "../../components/tasks/Show";
 import TaskNewAndEdit from "../../components/tasks/NewAndEdit.vue";
@@ -91,7 +84,7 @@ export default {
       this.axios
         .get(url)
         .then((response) => {
-          this.tasks = response.data.tasks;
+          this.tasks =  Object.freeze(response.data.tasks); //再代入を禁止にした。これがないと、v-modelの作用がglobalに影響を与えてしまうバグがでた。
           this.users = response.data.users;
         })
         .catch((error) => {

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -52,7 +52,6 @@ ActiveRecord::Schema.define(version: 2020_08_17_020422) do
     t.boolean "admin", default: false, null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.index ["email"], name: "index_users_on_email", unique: true
   end
 
   add_foreign_key "tag_tasks", "tags"


### PR DESCRIPTION
## 処理概要
- バリデーションエラーがブラウザで表示されるようにしました。
- 編集ページでのv-modelが、TaskListCard.vue含め、プロダクト全体に反映されてしまうバグが見つかったので、直しました。

## 要件・仕様
-  api/tasks_controller.rbでrescueをもちいて、バリデーションのエラーハンドリングしています。
- エラーはダイアログボックスのなかに表示されます。
- Object.freezeをもちいて、Index.vueのtasksを再代入禁止にしました。これで子コンポーネント内のv-modelの影響を受けなくなりました。

## 動作確認
タスクのタイトル、30文字を超えるとエラーが表示されます。0文字のときは、バリデーション云々の以前に、リクエストを送れないようにしています。
<img width="1907" alt="スクリーンショット 2020-08-17 16 49 01" src="https://user-images.githubusercontent.com/46987763/90371235-9c06af00-e0a9-11ea-8ed9-138e6df15a79.png">
<img width="1907" alt="スクリーンショット 2020-08-17 16 48 26" src="https://user-images.githubusercontent.com/46987763/90371240-9f9a3600-e0a9-11ea-84bf-869900c9c1c9.png">
<img width="1907" alt="スクリーンショット 2020-08-17 16 47 57" src="https://user-images.githubusercontent.com/46987763/90371241-a032cc80-e0a9-11ea-8a9b-6d7276e4c84c.png">

## 特記
- 先ほどのバリデーションの設定のブランチの続編になります。なので、先ほどのブランチをマージしていただいて、ブラウザのリロード後に、こちらのレビューをお願いします。

## 意見をもらいたい箇所 

## 参考
-  <a href='https://developer.mozilla.org/ja/docs/Web/JavaScript/Reference/Global_Objects/Object/freeze' >Object.freeze　について　</a>
- <a href='https://qiita.com/ngron/items/4c319ae7340b72c7e566'>【Rails】例外処理の書き方(begin, rescue, raise,retry, ensure) </a>
