### PR TITLE
ステップ24: ユーザにロールを追加しよう

### DIFF
--- a/app/controllers/api/admin_controller.rb
+++ b/app/controllers/api/admin_controller.rb
@@ -20,8 +20,8 @@ class Api::AdminController < Api::ApplicationController
 
   def destroy
     current_user = User.find_by(token: session[:token])
-    if current_user.id == params[:id]
-      render json: { message: '自分で自分のアカウントは削除できません' }, status: :unprocessable_entity
+    if current_user.id == params[:id] || User.count == 1
+      render json: { message: '自分で自分のアカウントは削除できません。もしくはあなたが最後のアドミンユーザーなのでアカウントを削除できません。' }, status: :unprocessable_entity
     else
       user = User.find(params[:id])
       tasks = user.tasks
@@ -35,9 +35,7 @@ class Api::AdminController < Api::ApplicationController
 
   def admin?
     is_admin = User.find_by(token: session[:token]).admin
-    if is_admin == false
-      raise NoAdminUserError
-    end
+    raise NoAdminUserError if is_admin == false
   end
 
   def user_params
@@ -48,5 +46,4 @@ class Api::AdminController < Api::ApplicationController
     logger.debug(error)
     render status: :unauthorized, json: { error: error }
   end
-
 end

--- a/app/controllers/api/admin_controller.rb
+++ b/app/controllers/api/admin_controller.rb
@@ -32,7 +32,7 @@ class Api::AdminController < Api::ApplicationController
   def destroy
     current_user = User.find_by(token: session[:token])
     if current_user.id == params[:id] || User.count == 1
-      render json: { message: '自分で自分のアカウントは削除できません。もしくはあなたが最後のアドミンユーザーなのでアカウントを削除できません。' }, status: :unprocessable_entity
+      render json: { message: '自分で自分のアカウントは削除できません。もしくはあなたが最後の管理者ユーザーなのでアカウントを削除できません。' }, status: :unprocessable_entity
     else
       user = User.find(params[:id])
       tasks = user.tasks
@@ -46,7 +46,7 @@ class Api::AdminController < Api::ApplicationController
 
   def admin?
     is_admin = User.find_by(token: session[:token]).admin
-    raise NoAdminUserError if is_admin == false
+    raise NoAdminUserError unless is_admin
   end
 
   def user_params

--- a/app/controllers/api/application_controller.rb
+++ b/app/controllers/api/application_controller.rb
@@ -50,7 +50,7 @@ class Api::ApplicationController < ActionController::API
   end
 
   class NoAdminUserError < StandardError
-    def initialize(msg = 'Admin権限がありません')
+    def initialize(msg = '管理者権限がありません')
       super
     end
   end

--- a/app/controllers/api/application_controller.rb
+++ b/app/controllers/api/application_controller.rb
@@ -50,7 +50,7 @@ class Api::ApplicationController < ActionController::API
   end
 
   class NoAdminUserError < StandardError
-    def initialize(msg="Admin権限がありません")
+    def initialize(msg = 'Admin権限がありません')
       super
     end
   end

--- a/app/controllers/api/application_controller.rb
+++ b/app/controllers/api/application_controller.rb
@@ -48,4 +48,10 @@ class Api::ApplicationController < ActionController::API
       username == ENV['BASIC_AUTH_USER'] && password == ENV['BASIC_AUTH_PASSWORD']
     end
   end
+
+  class NoAdminUserError < StandardError
+    def initialize(msg="Admin権限がありません")
+      super
+    end
+  end
 end

--- a/app/javascript/views/admin/DashBoard.vue
+++ b/app/javascript/views/admin/DashBoard.vue
@@ -134,11 +134,13 @@ export default {
         Authorization: "Token " + token,
       };
       const response = await this.axios.get(url).catch((error) => {
-        console.log(error);
+        console.log(error.response.data.error);
         alert("エラーが起きました！");
       });
-      this.users_tasks = null;
-      this.users_tasks = response.data.users_tasks;
+      if (response) {
+        this.users_tasks = null;
+        this.users_tasks = response.data.users_tasks;
+      }
     },
     async addUser() {
       if (this.email === "" || this.email === null) {

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,15 +3,19 @@
 class User < ApplicationRecord
   has_secure_token
   before_save { self.email = email.downcase } # メールアドレスは大文字・小文字を区別しないので、データベースに登録前に小文字に戻す
-
-  VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i.freeze
+  before_destroy :last_record?
+    .VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i.freeze
 
   has_many :tasks, dependent: :destroy
 
   validates :name, presence: true, length: { maximum: 20 } # 名前は１文字以上20文字以下
-  validates :email, presence: true, format: { with: VALID_EMAIL_REGEX }, uniqueness: { case_sensitive: false } # uniqueness:{ case_sensitive: false }で、メールアドレスのバリデーションで、大文字・小文字の区別を無くしている　
+  validates :email, presence: true, format: { with: VALID_EMAIL_REGEX }, uniqueness: { case_sensitive: false } # uniqueness:{ case_sensitive: false }で、メールアドレスのバリデーションで、大文字・小文字の区別を無くしている
   validates :password_digest, presence: true
   validates :introduction, length: { maximum: 150 }
   validates :permission, inclusion: { in: [true, false] }
   validates :admin, inclusion: { in: [true, false] }
+
+  def last_record?
+    User.count > 1
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,7 +4,7 @@ class User < ApplicationRecord
   has_secure_token
   before_save { self.email = email.downcase } # メールアドレスは大文字・小文字を区別しないので、データベースに登録前に小文字に戻す
   before_destroy :last_record?
-    .VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i.freeze
+  VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i.freeze
 
   has_many :tasks, dependent: :destroy
 


### PR DESCRIPTION

## 処理概要
- ステップ24: ユーザにロールを追加しよう
- 一般ユーザーがAdminにアクセスした時の処理を追加

## 要件・仕様
- もともとAdminの識別のカラムは作ってあったので、今回特別追加などはしていません
- ステップ23でAdminの一覧ページでユーザーのroleは確認できるようにしてあり、新規ユーザー登録やユーザー編集でroleをいじれるようにしてあるので、今回のステップでは特別処理を加えてはいません
- 僕のタスクアプリは自分で自分のアカウントの削除はできないような仕様にしたので、そもそもユーザーが0人になることはないです。
## 動作確認
- そもそもこのプロダクトはAdminユーザーじゃない限り、Admin画面へのリンクは表示されませんし、無理やりAdminのURLを直接入力してAdminにアクセスしようとしても強制的にタスク一覧ページにリダイレクトさせるようになっています。なので通常の場合、一般ユーザーがAdminにリクエストを送るシチュエーションはおきません。
が、その機能を一時的に無効にして、あえて一般ユーザーが直接Adminにリクエストを送ったらどうなるかの動作確認をしたものが以下になります。しっかり専用のエラーが発生していることがわかります。

<img width="1919" alt="スクリーンショット 2020-10-28 15 34 52" src="https://user-images.githubusercontent.com/46987763/97821690-ae7ea500-1cf6-11eb-9b94-3d6e299c0717.png">
<img width="1919" alt="スクリーンショット 2020-10-28 16 22 06" src="https://user-images.githubusercontent.com/46987763/97821723-cbb37380-1cf6-11eb-8e7c-3490f8cf5544.png">

## 特記
- 複雑な処理が含まれる場合は、設計・実装方針を記載してください
- コードにコメントと言う形での記載も可

## 意見をもらいたい箇所 
- 実装上、動作確認時に確認すべき箇所がある場合は記載してください

## 参考
- 参考URLなどあれば
