### PR TITLE
エラー処理の分離

### DIFF
--- a/app/javascript/components/Header.vue
+++ b/app/javascript/components/Header.vue
@@ -27,8 +27,7 @@ export default {
             this.$store.dispatch("auth/signout");
           })
           .catch((error) => {
-            console.log(error);
-            alert("エラーが起きました！");
+            this.rescue(error)
           });
       }
     },

--- a/app/javascript/components/tasks/NewAndEdit.vue
+++ b/app/javascript/components/tasks/NewAndEdit.vue
@@ -231,12 +231,7 @@ export default {
             this.$emit("update:is_new_and_edit", false);
           })
           .catch((error) => {
-            console.dir(error);
-            if(error.response.status === 500){
-              this.$router.push('/500error')
-            }else{
-              alert('エラーが発生しました！')
-            }
+            this.rescue(error)
           });
       } else {
         //更新の場合
@@ -253,12 +248,7 @@ export default {
             this.$emit("update:is_new_and_edit", false);
           })
           .catch((error) => {
-            console.dir(error);
-            if(error.response.status === 500){
-              this.$router.push('/500error')
-            }else{
-              alert('エラーが発生しました！')
-            }
+            this.rescue(error)
           });
       }
     },

--- a/app/javascript/components/tasks/Search.vue
+++ b/app/javascript/components/tasks/Search.vue
@@ -84,12 +84,7 @@ export default {
           }
         })
         .catch((error) => {
-          console.dir(error);
-          if(error.response.status === 500){
-            this.$router.push('/500error')
-          }else{
-            alert('エラーが発生しました！')
-          }
+          this.rescue(error)
         });
     },
   },

--- a/app/javascript/components/tasks/TaskListCard.vue
+++ b/app/javascript/components/tasks/TaskListCard.vue
@@ -65,12 +65,7 @@ export default {
           alert("削除が完了しました！");
         })
         .catch((error) => {
-          console.dir(error);
-          if(error.response.status === 500){
-            this.$router.push('/500error')
-          }else{
-            alert('エラーが発生しました！')
-          }
+          this.rescue(error)
         });
     },
   },

--- a/app/javascript/mixins/errors/error.js
+++ b/app/javascript/mixins/errors/error.js
@@ -1,0 +1,17 @@
+import router from "../../routes/router";
+export default {
+  methods: {
+    rescue(error) {
+      try {
+        console.dir(error);
+        if (error.response.status === 500) {
+          router.push("/500error");
+        } else {
+          alert("エラーが発生しました！");
+        }
+      } catch (err) {
+        console.dir(err);
+      }
+    },
+  },
+};

--- a/app/javascript/packs/hello_vue.js
+++ b/app/javascript/packs/hello_vue.js
@@ -6,6 +6,8 @@ import router from "../routes/router.js";
 import App from "../app.vue";
 import axios from "axios";
 import VueAxios from "vue-axios";
+import errorHandlers from "../mixins/errors/error.js";
+Vue.mixin(errorHandlers);
 Vue.use(Vuex);
 Vue.use(VueRouter);
 Vue.use(VueAxios, axios);

--- a/app/javascript/store/modules/auth.js
+++ b/app/javascript/store/modules/auth.js
@@ -1,4 +1,5 @@
 import router from "../../routes/router.js";
+import errors from "../../mixins/errors/error";
 export default {
   namespaced: true,
   state: {
@@ -19,66 +20,56 @@ export default {
     },
   },
   actions: {
-    signin({ commit, dispatch }, data) {
-      dispatch(
-        "http/post",
-        { url: "/api/auth/signin", data, error: "message.unauthorized" },
-        { root: true }
-      )
-        .then((res) => commit("create", res.data))
-        .catch((error) => {
-          console.dir(error);
-          if (error.response.status === 500) {
-            this.$router.push("/500error");
-          } else {
-            alert("エラーが発生しました！");
-          }
-        });
-    },
-    signup({ commit, dispatch }, data) {
-      dispatch(
-        "http/post",
-        { url: "/api/auth/signup", data, error: "message.unauthorized" },
-        { root: true }
-      )
-        .then((res) => {
+    async signin({ commit, dispatch }, data) {
+      try {
+        const res = await dispatch(
+          "http/post",
+          { url: "/api/auth/signin", data, error: "message.unauthorized" },
+          { root: true }
+        );
+        if (res) {
           commit("create", res.data);
-          dispatch("setToken");
-        })
-        .catch((error) => {
-          console.dir(error);
-          if (error.response.status === 500) {
-            router.push("/500error");
-          } else {
-            alert("エラーが発生しました！");
-          }
-        });
+        }
+      } catch (error) {
+        errors.methods.rescue(error);
+      }
     },
-    signout({ commit, dispatch }) {
-      commit("destroy");
-      dispatch("user/deleteCurrentUserAction", null, { root: true });
-      router.push("/signin");
+    async signup({ commit, dispatch }, data) {
+      try {
+        const res = await dispatch(
+          "http/post",
+          { url: "/api/auth/signup", data, error: "message.unauthorized" },
+          { root: true }
+        );
+        commit("create", res.data);
+        dispatch("setToken");
+      } catch (error) {
+        errors.methods.rescue(error);
+      }
     },
-    setToken({ commit, dispatch }) {
-      dispatch(
-        "http/get",
-        { url: "/api/auth/get_token", error: "no token" },
-        { root: true }
-      )
-        .then((res) => {
-          if (res.data) {
-            commit("create", res.data);
-            dispatch("user/setCurrentUserAction", null, { root: true });
-          }
-        })
-        .catch((err) => {
-          console.dir(error);
-          if (error.response.status === 500) {
-            router.push("/500error");
-          } else {
-            alert("エラーが発生しました！");
-          }
-        });
+    async signout({ commit, dispatch }) {
+      try {
+        commit("destroy");
+        await dispatch("user/deleteCurrentUserAction", null, { root: true });
+        router.push("/signin");
+      } catch (error) {
+        errors.methods.rescue(error);
+      }
+    },
+    async setToken({ commit, dispatch }) {
+      try {
+        const res = await dispatch(
+          "http/get",
+          { url: "/api/auth/get_token", error: "no token" },
+          { root: true }
+        );
+        if (res.data) {
+          commit("create", res.data);
+          dispatch("user/setCurrentUserAction", null, { root: true });
+        }
+      } catch (error) {
+        errors.methods.rescue(error);
+      }
     },
   },
 };

--- a/app/javascript/store/modules/http.js
+++ b/app/javascript/store/modules/http.js
@@ -1,4 +1,5 @@
 import axios from "axios";
+import errors from "../../mixins/errors/error";
 
 export default {
   namespaced: true,
@@ -21,8 +22,8 @@ export default {
 
       return axios(options)
         .then((res) => res)
-        .catch((err) => {
-          alert(err.response.data.error);
+        .catch((error) => {
+          errors.methods.rescue(error);
         });
     },
     async post({ dispatch }, requests) {

--- a/app/javascript/store/modules/user.js
+++ b/app/javascript/store/modules/user.js
@@ -52,12 +52,7 @@ export default {
           });
         })
         .catch((error) => {
-          console.dir(error);
-          if (error.response.status === 500) {
-            router.push("/500error");
-          } else {
-            alert("エラーが発生しました！");
-          }
+          this.rescue(error);
         });
     },
     deleteCurrentUserAction(context) {

--- a/app/javascript/views/admin/DashBoard.vue
+++ b/app/javascript/views/admin/DashBoard.vue
@@ -126,18 +126,14 @@ export default {
         "X-Requested-With": "XMLHttpRequest",
         Authorization: "Token " + token,
       };
-      const response = await this.axios.get(url).catch((error) => {
-        console.log(error.response.data.error);
-        alert("エラーが起きました！");
-        if (error.response.status === 500) {
-          this.$router.push('/500error')
-        } else {
-          alert('エラーが発生しました！')
+      try{
+        const response = await this.axios.get(url)
+        if (response) {
+          this.users_tasks = null;
+          this.users_tasks = response.data.users_tasks;
         }
-      });
-      if (response) {
-        this.users_tasks = null;
-        this.users_tasks = response.data.users_tasks;
+      } catch (error) {
+          this.rescue(error)
       }
     },
     async addUser() {
@@ -170,20 +166,18 @@ export default {
         "X-Requested-With": "XMLHttpRequest",
         Authorization: "Token " + token,
       };
-      const response = await this.axios.post(url, { user }).catch((error) => {
-        console.log(error.response.data.error);
-        this.is_new = false;
-        if (error.response.status === 500) {
-          this.$router.push('/500error')
-        } else {
-          alert('エラーが発生しました！')
+      try {
+        const response = await this.axios.post(url, { user })
+        if (response && response.status === 200) {
+          alert("ユーザーを作成しました");
+          this.getUsersAndTasks();
+          this.is_new = false;
         }
-      });
-      if (response && response.status === 200) {
-        alert("ユーザーを作成しました");
-        this.getUsersAndTasks();
-        this.is_new = false;
-      }
+      } catch (error) {
+          this.is_new = false;
+          this.rescue(error)
+      };
+    
     },
   },
 

--- a/app/javascript/views/admin/ManageUser.vue
+++ b/app/javascript/views/admin/ManageUser.vue
@@ -150,12 +150,7 @@ export default {
           this.$router.push("/admin/dashboard");
           
         } catch (error) {
-          console.dir(error)
-          if (error.response.status === 500) {
-            this.$router.push('/500error')
-          } else {
-            alert('エラーが発生しました！')
-          }
+            this.rescue(error)
         }
       }
     },
@@ -177,13 +172,7 @@ export default {
         alert("更新しました！");
         this.$router.push("/admin/dashboard");
       } catch (error) {
-        console.dir(error)
-        if (error.response.status === 500) {
-          this.$router.push('/500error')
-          return
-        } else {
-          alert('エラーが発生しました！')
-        }
+          this.rescue(error)
       }
     },
   },

--- a/app/javascript/views/tasks/Index.vue
+++ b/app/javascript/views/tasks/Index.vue
@@ -153,12 +153,7 @@ export default {
           this.users = response.data.users;
         })
         .catch((error) => {
-          console.dir(error);
-          if(error.response.status === 500){
-            this.$router.push('/500error')
-          }else{
-            alert('エラーが発生しました！')
-          }
+          this.rescue(error)
         });
     },
     showFunc(task) {


### PR DESCRIPTION
## 処理概要
- mixinでエラー処理の部分を分離しました

## 要件・仕様
- mixinフォルダをつくり、その中にerror.jsをつくってエラー処理を書き、hello_vue.jsでグローバル登録しています
- 各Vueファイルのリクエストのcatch のブロックの中で、mixinの中のエラー処理のmethodを呼び出しています。

## 動作確認
- 管理者としてのアカウントのマネジメント、サインイン、サインアップ、サインアウト、タスクの管理一式　における全てのリクエストで500をわざとお越し、動作することを確認済みです。

## 特記
- これ以上の分離をするとなると、axiosそのものをmixinにしてあげる必要があります　不可能ではないですが結構工数がかかりそうなので、一回これでレビューをお願いします！

## 意見をもらいたい箇所 
- 実装上、動作確認時に確認すべき箇所がある場合は記載してください

## 参考
- [vue.js methodsやcomputedを共通化(mixin)する](https://qiita.com/mah666hhh/items/91516c85c74bd1358139)
